### PR TITLE
Add mapping name to Export

### DIFF
--- a/amber_lib/models/primaries.py
+++ b/amber_lib/models/primaries.py
@@ -84,6 +84,7 @@ class Export(Model):
     date_created = Property(str)
     date_exported = Property(str)
     mapping_id = Property(int)
+    mapping_name = Property(str)
     message = Property(str)
     status = Property(str)
 


### PR DESCRIPTION
Adds a mapping name to the export object so the export worker will no longer need to query the DB for it itself.

Relies on:
* API: https://github.com/AmberEngine/api/pull/197
* CM: https://github.com/AmberEngine/channel-manager/pull/1031