### PR TITLE
Removes need for an asterisk for within and not_in

### DIFF
--- a/amber_lib/query.py
+++ b/amber_lib/query.py
@@ -1,3 +1,4 @@
+import collections
 import json
 
 
@@ -9,8 +10,10 @@ class Predicate(object):
     def to_dict(self):
         return {self.path: self.expression}
 
+
 AND = "&&"
 OR = "||"
+
 
 class _Operator(object):
     def __init__(self, type_, *preds):
@@ -34,46 +37,56 @@ class _Operator(object):
     def to_json(self):
         return json.dumps(self.to_dict())
 
+
 class And(_Operator):
     def __init__(self, *preds):
         _Operator.__init__(self, AND, *preds)
+
 
 class Or(_Operator):
     def __init__(self, *preds):
         _Operator.__init__(self, OR, *preds)
 
+
 def equal(value):
     return {"==": value}
+
 
 def not_equal(value):
     return {"!=": value}
 
-def within(*value):
-    if not isinstance(value, tuple):
+
+def within(value):
+    if not isinstance(value, collections.Iterable):
         raise TypeError()
     return {"in": value}
 
-def not_in(*value):
+
+def not_in(value):
     if not isinstance(value, tuple):
         raise TypeError()
     return {"!in": value}
 
+
 def min(value):
     return {">=": value}
+
 
 def max(value):
     return {"<=": value}
 
+
 def greater_than(value):
     return {">": value}
+
 
 def less_than(value):
     return {"<": value}
 
+
 def is_null():
     return {"null": ""}
 
+
 def is_not_null():
     return {"!null": ""}
-
-

--- a/amber_lib/query.py
+++ b/amber_lib/query.py
@@ -63,7 +63,7 @@ def within(value):
 
 
 def not_in(value):
-    if not isinstance(value, tuple):
+    if not isinstance(value, collections.Iterable):
         raise TypeError()
     return {"!in": value}
 


### PR DESCRIPTION
Fixes:
* Removes the need for an asterisk when passing iterable values to the within or not_in methods of query.

PT: https://www.pivotaltracker.com/story/show/117168765

Relies on:
* API: https://github.com/AmberEngine/api/pull/211
* CM: https://github.com/AmberEngine/channel-manager/pull/1045