### PR TITLE
[Hotfix] And a kwarg to prevent refresh on relate calls

### DIFF
--- a/amber_lib/models/bases.py
+++ b/amber_lib/models/bases.py
@@ -206,10 +206,10 @@ class Model(object):
 
         return collection
 
-    def relate(self, obj):
+    def relate(self, obj, refresh=True):
         """ Create a relation between this object and another.
         """
-        self.set_relation(True, obj)
+        self.set_relation(True, obj, refresh=refresh)
 
     def retrieve(self, id_=None):
         """ Retrieve the data for a database entry constrained by the
@@ -267,7 +267,7 @@ class Model(object):
         self.update(returned_dict)
         return self
 
-    def set_relation(self, bool_, obj):
+    def set_relation(self, bool_, obj, refresh=True):
         """ Create or remove a relation between the current model and a
         different model.
         """
@@ -284,7 +284,8 @@ class Model(object):
         # Dear Future Dev, if you're wondering why changes are disappearing
         # when relate/unrelate calls are made then this line is why, but
         # without it then relate/unrelate changes disappear on save calls.
-        self.refresh()
+        if refresh:
+            self.refresh()
 
     def to_dict(self):
         """ Retrieve a dictionary version of the model.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='amber-lib',
-    version='1.2.1',
+    version='1.2.2',
     packages=['amber_lib'],
     license='Other/Proprietary License',
     long_description=open('README.md').read(),


### PR DESCRIPTION
In some cases, e.g. with imports, the updated state of an object is not required after a relate call is made, so refresh just adds (not insignificant) overhead. This PR is to add an optional refresh kwarg to the relate call which can suppress calling refresh() if the kwarg is set to false (by default it's true and the original behavior is maintained). 

Jirra: https://amberengine.atlassian.net/browse/DM-67