### PR TITLE
fixed nailhead option typo

### DIFF
--- a/amber_lib/models/primaries.py
+++ b/amber_lib/models/primaries.py
@@ -306,7 +306,7 @@ class Option(Model):
     kind = Property(str)
     leather = Property(Leather)
     leg = Property(Leg)
-    nail_head = Property(Nailhead)
+    nailhead = Property(Nailhead)
     name = Property(str)
     number = Property(str)
     option_set_id = Property(int)


### PR DESCRIPTION
Signed-off-by: Curtis La Graff <curtis@amberengine.com>
Fixes: https://amberengine.atlassian.net/browse/DM-143

Convert `nail_head` to `nailhead`.